### PR TITLE
Manually pin site language as English

### DIFF
--- a/budget.json
+++ b/budget.json
@@ -1,30 +1,30 @@
 [
-    {
-       "path":"/*",
-       "resourceSizes":[
-          {
-             "resourceType":"total",
-             "budget":300
-          },
-          {
-             "resourceType":"script",
-             "budget":150
-          }
-       ],
-       "resourceCounts":[
-          {
-             "resourceType":"third-party",
-             "budget":10
-          }
-       ]
-    },
-    {
-       "path":"/",
-       "resourceSizes":[
-          {
-             "resourceType":"total",
-             "budget":200
-          }
-       ]
-    }
- ]
+  {
+    "path": "/*",
+    "resourceSizes": [
+      {
+        "resourceType": "total",
+        "budget": 300
+      },
+      {
+        "resourceType": "script",
+        "budget": 150
+      }
+    ],
+    "resourceCounts": [
+      {
+        "resourceType": "third-party",
+        "budget": 10
+      }
+    ]
+  },
+  {
+    "path": "/",
+    "resourceSizes": [
+      {
+        "resourceType": "total",
+        "budget": 200
+      }
+    ]
+  }
+]

--- a/lighthouserc_local.json
+++ b/lighthouserc_local.json
@@ -1,7 +1,7 @@
 {
-    "ci": {
-      "collect": {
-        "staticDistDir": "./public"
-      }
+  "ci": {
+    "collect": {
+      "staticDistDir": "./public"
     }
   }
+}

--- a/src/components/common/navigation/navigation.tsx
+++ b/src/components/common/navigation/navigation.tsx
@@ -22,7 +22,7 @@ const Navigation = () => {
 
   const data = useStaticQuery(graphql`
     query {
-      prismicNavigation {
+      prismicNavigation(lang: {eq: "en-us"}) {
         data {
           navigation_links {
             title

--- a/src/components/common/navigation/navigation.tsx
+++ b/src/components/common/navigation/navigation.tsx
@@ -22,7 +22,7 @@ const Navigation = () => {
 
   const data = useStaticQuery(graphql`
     query {
-      prismicNavigation(lang: {eq: "en-us"}) {
+      prismicNavigation(lang: { eq: "en-us" }) {
         data {
           navigation_links {
             title

--- a/src/components/sections/benefits.tsx
+++ b/src/components/sections/benefits.tsx
@@ -18,7 +18,7 @@ interface BenefitsPage {
 const Benefits = () => {
   const data = useStaticQuery(graphql`
     query {
-      prismicHomePage(lang: {eq: "en-us"}) {
+      prismicHomePage(lang: { eq: "en-us" }) {
         data {
           benefits_subtitle
           benefits_section_title

--- a/src/components/sections/benefits.tsx
+++ b/src/components/sections/benefits.tsx
@@ -18,7 +18,7 @@ interface BenefitsPage {
 const Benefits = () => {
   const data = useStaticQuery(graphql`
     query {
-      prismicHomePage {
+      prismicHomePage(lang: {eq: "en-us"}) {
         data {
           benefits_subtitle
           benefits_section_title

--- a/src/components/sections/footer.tsx
+++ b/src/components/sections/footer.tsx
@@ -8,7 +8,7 @@ import NavLink, { NavLinkProps } from "../common/navlink";
 const Footer = () => {
   const data = useStaticQuery(graphql`
     query {
-      prismicNavigation(lang: {eq: "en-us"}) {
+      prismicNavigation(lang: { eq: "en-us" }) {
         data {
           footer_column_one_title
           footer_column_one_links {

--- a/src/components/sections/footer.tsx
+++ b/src/components/sections/footer.tsx
@@ -8,7 +8,7 @@ import NavLink, { NavLinkProps } from "../common/navlink";
 const Footer = () => {
   const data = useStaticQuery(graphql`
     query {
-      prismicNavigation {
+      prismicNavigation(lang: {eq: "en-us"}) {
         data {
           footer_column_one_title
           footer_column_one_links {

--- a/src/components/sections/getstarted.tsx
+++ b/src/components/sections/getstarted.tsx
@@ -7,7 +7,7 @@ import { Container, Section } from "../global";
 const GetStarted = () => {
   const data = useStaticQuery(graphql`
     query {
-      prismicHomePage(lang: {eq: "en-us"}) {
+      prismicHomePage(lang: { eq: "en-us" }) {
         data {
           get_started_title
           try_it_button_text

--- a/src/components/sections/getstarted.tsx
+++ b/src/components/sections/getstarted.tsx
@@ -7,7 +7,7 @@ import { Container, Section } from "../global";
 const GetStarted = () => {
   const data = useStaticQuery(graphql`
     query {
-      prismicHomePage {
+      prismicHomePage(lang: {eq: "en-us"}) {
         data {
           get_started_title
           try_it_button_text

--- a/src/components/sections/header.tsx
+++ b/src/components/sections/header.tsx
@@ -15,7 +15,7 @@ const Header = () => {
           }
         }
       }
-      prismicHomePage {
+      prismicHomePage(lang: {eq: "en-us"}) {
         data {
           header_subtitle
           header_title_one

--- a/src/components/sections/header.tsx
+++ b/src/components/sections/header.tsx
@@ -15,7 +15,7 @@ const Header = () => {
           }
         }
       }
-      prismicHomePage(lang: {eq: "en-us"}) {
+      prismicHomePage(lang: { eq: "en-us" }) {
         data {
           header_subtitle
           header_title_one


### PR DESCRIPTION
We have multiple translations, so the build process will just pick whichever gets returned first. This is not ideal. Let's pin it for now and then figure out how to switch them around.