### PR TITLE
Gatsby should not be setting ACLs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -96,6 +96,7 @@ module.exports = {
         bucketName: siteDomainName,
         protocol: "https",
         hostname: siteDomainName,
+        acl: null,
       },
     },
 


### PR DESCRIPTION
Deploys fails because we are not setting ACLs