### PR TITLE
Point to the fluentlabs backend

### DIFF
--- a/src/client/api/ApiClient.ts
+++ b/src/client/api/ApiClient.ts
@@ -23,7 +23,7 @@ export class ApiClient {
   hostname =
     window.location.hostname === "localhost"
       ? "http://localhost:9000"
-      : "https://api.foreignlanguagereader.com";
+      : "https://api.fluentlabs.io";
 
   getDefinition = async (
     language: string,


### PR DESCRIPTION
We've moved the backend, let's point requests to it.