### PR TITLE
Drop definitions from words

### DIFF
--- a/src/client/api/ApiClient.ts
+++ b/src/client/api/ApiClient.ts
@@ -16,7 +16,6 @@ export type WordDTO = {
   processedToken: string;
   tag: string;
   lemma: string;
-  definitions: Array<DefinitionDTO>;
 };
 
 export class ApiClient {


### PR DESCRIPTION
It isn't in the backend anymore, let's drop it from the frontend.