### PR TITLE
Disable flapping accessibility test

### DIFF
--- a/cypress/integration/demo.test.ts
+++ b/cypress/integration/demo.test.ts
@@ -35,15 +35,4 @@ describe("Check the demo page page", function () {
       "ant-typography-secondary"
     );
   });
-
-  // This test is flapping, disable until we can investigate
-  // it("Is fully accessible", function () {
-  //   cy.injectAxe();
-  //   cy.checkA11y(null, {
-  //     includedImpacts: ["serious"],
-  //     rules: {
-  //       "color-contrast": { enabled: false },
-  //     },
-  //   });
-  // });
 });

--- a/cypress/integration/demo.test.ts
+++ b/cypress/integration/demo.test.ts
@@ -36,13 +36,14 @@ describe("Check the demo page page", function () {
     );
   });
 
-  it("Is fully accessible", function () {
-    cy.injectAxe();
-    cy.checkA11y(null, {
-      includedImpacts: ["serious"],
-      rules: {
-        "color-contrast": { enabled: false },
-      },
-    });
-  });
+  // This test is flapping, disable until we can investigate
+  // it("Is fully accessible", function () {
+  //   cy.injectAxe();
+  //   cy.checkA11y(null, {
+  //     includedImpacts: ["serious"],
+  //     rules: {
+  //       "color-contrast": { enabled: false },
+  //     },
+  //   });
+  // });
 });


### PR DESCRIPTION
It's breaking our builds, and can be fixed by just re-running it. Until it's more reliable, it shouldn't break the pipeline.